### PR TITLE
Add gh-pages url to cors allowlist

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,7 +5,7 @@ const routes = require('./routes')
 const cors = require('cors')
 const app = express();
 app.use(bodyParser.json());
-app.use(cors({ origin: ['https://antalmanac.com', 'https://www.antalmanac.com']}))
+app.use(cors({ origin: ['https://antalmanac.com', 'https://www.antalmanac.com', 'https://icssc-projects.github.io/AntAlmanac']}))
 app.use('/api', routes)
 
 module.exports.handler = serverless(app, {binary: ['image/*']});


### PR DESCRIPTION
Currently experimenting with moving the frontend over to Github Pages.  
This commit adds the github url to our cors policy, so we can use the backend api during testing. 

If we decide to switch over to gh-pages, then we'll point the `antalamanc.com` url at github and can remove `icssc-projects.github.io/AntAlmanac`.